### PR TITLE
Fix duplicated datetime

### DIFF
--- a/Trainer/Pages/ActivityEntry.razor
+++ b/Trainer/Pages/ActivityEntry.razor
@@ -128,7 +128,7 @@
                         {
                             Id = 0,
                             ActivityTypeId = sourceActivity.ActivityTypeId,
-                            When = sourceActivity.When,
+                            When = DateTime.Now,
                             Amount = sourceActivity.Amount,
                             Notes = sourceActivity.Notes
                         };


### PR DESCRIPTION
Duplicated activities should default to now instead of the copied date/time