### PR TITLE
Add neutral benefit type

### DIFF
--- a/Trainer/Models/ActivityType.cs
+++ b/Trainer/Models/ActivityType.cs
@@ -4,7 +4,7 @@ public record ActivityType
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
-    public NetBenefit NetBenefit { get; set; } = NetBenefit.None;
+    public NetBenefit NetBenefit { get; set; } = NetBenefit.Neutral;
     public int? DailyAmount { get; set; }
     public int? WeeklyAmount { get; set; }
     public string? Unit { get; set; }

--- a/Trainer/Models/NetBenefit.cs
+++ b/Trainer/Models/NetBenefit.cs
@@ -2,7 +2,7 @@ namespace Trainer.Models;
 
 public enum NetBenefit
 {
-    None,
+    Neutral,
     Positive,
     Negative
 }

--- a/Trainer/Pages/ActivityTypeEntry.razor
+++ b/Trainer/Pages/ActivityTypeEntry.razor
@@ -22,13 +22,18 @@
         <div class="mb-3">
             <label class="form-label">Net Benefit</label>
             <div class="btn-group mt-2" role="group">
-                <button type="button" 
-                        class="btn @(activityType.NetBenefit == NetBenefit.Positive ? "btn-success" : "btn-outline-success")" 
+                <button type="button"
+                        class="btn @(activityType.NetBenefit == NetBenefit.Positive ? "btn-success" : "btn-outline-success")"
                         @onclick="() => ToggleNetBenefit(NetBenefit.Positive)">
                     Positive
                 </button>
-                <button type="button" 
-                        class="btn @(activityType.NetBenefit == NetBenefit.Negative ? "btn-danger" : "btn-outline-danger")" 
+                <button type="button"
+                        class="btn @(activityType.NetBenefit == NetBenefit.Neutral ? "btn-secondary" : "btn-outline-secondary")"
+                        @onclick="() => ToggleNetBenefit(NetBenefit.Neutral)">
+                    Neutral
+                </button>
+                <button type="button"
+                        class="btn @(activityType.NetBenefit == NetBenefit.Negative ? "btn-danger" : "btn-outline-danger")"
                         @onclick="() => ToggleNetBenefit(NetBenefit.Negative)">
                     Negative
                 </button>
@@ -103,15 +108,7 @@
 
     private void ToggleNetBenefit(NetBenefit benefit)
     {
-        // If clicking the same option, deselect it (set to None)
-        if (activityType.NetBenefit == benefit)
-        {
-            activityType.NetBenefit = NetBenefit.None;
-        }
-        else
-        {
-            activityType.NetBenefit = benefit;
-        }
+        activityType.NetBenefit = benefit;
     }
 
     private string GetNavigationPath(string path)

--- a/Trainer/Pages/Index.razor
+++ b/Trainer/Pages/Index.razor
@@ -187,7 +187,7 @@
                     TotalAmount = g.Sum(a => a.Amount),
                     ActivityType = activityTypes.FirstOrDefault(t => t.Id == g.Key)
                 })
-                .Where(x => x.ActivityType != null && x.ActivityType.NetBenefit != NetBenefit.None)
+                .Where(x => x.ActivityType != null && x.ActivityType.NetBenefit != NetBenefit.Neutral)
                 .ToList();
 
             // Calculate percentages and filter out activities without goals

--- a/openspec/changes/archive/2026-05-29-add-neutral-benefit/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-add-neutral-benefit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-add-neutral-benefit/design.md
+++ b/openspec/changes/archive/2026-05-29-add-neutral-benefit/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`NetBenefit` is a C# enum (`None = 0`, `Positive = 1`, `Negative = 2`) on `ActivityType`. The Home page chart filters out `None` and colors bars green/red. The `ActivityTypeEntry` page has a two-button toggle (Positive / Negative) that resets to `None` on second click, making `None` serve as a hidden "unset" state.
+
+The goal is to collapse "unset" and "neutral" into a single concept: `Neutral` is always the state if neither Positive nor Negative is chosen. No activity type is ever truly unclassified.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rename `None` → `Neutral` (same integer value `0`, zero migration cost)
+- Treat `Neutral` as a valid, intentional classification — never "unset"
+- Show neutral activity types in all list views (Home recent activities, Activities page, Calendar)
+- Exclude neutral activity types from the Home goal/duration chart
+- Replace the two-button toggle with a three-button selector (Positive | Neutral | Negative) with no deselect behavior
+
+**Non-Goals:**
+- Any IndexedDB schema or data migration (value `0` already stored for current "None" types; rename is transparent)
+- Changing chart behavior for Positive/Negative types
+- Filtering neutral activities from Calendar or Activities list views
+
+## Decisions
+
+### 1. Rename `None → Neutral` at value `0` rather than adding a new enum member
+Reusing `0` means all existing stored activity types that were `None` automatically become `Neutral` with no data migration. A new `Neutral = 3` would require a migration or leave old records misclassified. The rename is a pure refactor at the model layer.
+
+### 2. Remove deselect-to-None logic from the form
+Since `Neutral` is always a valid state (not "unset"), there is no reason to deselect. The three-button selector simply switches between the three values. This simplifies `ToggleNetBenefit` to an assignment with no toggle-off branch.
+
+### 3. Chart filter updated from `!= None` to `!= Neutral`
+The existing filter in `Index.razor` excludes `None` from chart data. Renaming the enum member is the only required change — the filter intent remains identical.
+
+## Risks / Trade-offs
+
+- [Reference rename] All existing references to `NetBenefit.None` must be updated to `NetBenefit.Neutral`. → Mitigation: grep for `NetBenefit.None` and `NetBenefit\.None` before shipping; the compiler will catch any missed references.
+- [UI regression] Three-button layout may overflow on small screens. → Mitigation: use Bootstrap `btn-group` with responsive sizing so it reflows gracefully.

--- a/openspec/changes/archive/2026-05-29-add-neutral-benefit/proposal.md
+++ b/openspec/changes/archive/2026-05-29-add-neutral-benefit/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Some trackable activities are neither beneficial nor harmful — they're neutral habits users want to log without skewing positive/negative trends. The current `None` value conflates "unset" with "neutral," and the binary Positive/Negative toggle UI gives no way to explicitly choose neutral. Renaming `None` to `Neutral` and treating it as a real, intentional classification removes the ambiguity.
+
+## What Changes
+
+- Rename `NetBenefit.None` to `NetBenefit.Neutral` (same integer value `0`, backwards-compatible with stored data)
+- `Neutral` is the default for new activity types and is never treated as "unset"
+- Update the Create/Edit Activity Type screen to show a three-way selector (green Positive, grey Neutral, red Negative) — no deselect/reset behavior needed since Neutral is always a valid state
+- Neutral activity types appear in activity lists (Home, Activities, Calendar) but are excluded from goal/benefit charts on the Home screen
+
+## Capabilities
+
+### New Capabilities
+- `neutral-benefit`: Renames `None` → `Neutral` and promotes it to a first-class classification, including the three-way UI selector and chart exclusion logic
+
+### Modified Capabilities
+
+## Impact
+
+- `Trainer/Models/NetBenefit.cs` — rename `None` to `Neutral` (value stays `0`)
+- `Trainer/Pages/ActivityTypeEntry.razor` — replace two-button toggle with three-button selector; remove deselect-to-None logic
+- `Trainer/Pages/Index.razor` — update chart filter from `!= None` to `!= Neutral`; add Neutral color case to color switch
+- Existing stored data unaffected (integer value `0` now maps to `Neutral` instead of `None`)

--- a/openspec/changes/archive/2026-05-29-add-neutral-benefit/specs/neutral-benefit/spec.md
+++ b/openspec/changes/archive/2026-05-29-add-neutral-benefit/specs/neutral-benefit/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Neutral is the default net benefit classification
+`NetBenefit.Neutral` (integer value `0`, renamed from `None`) SHALL be the default value for all activity types. No activity type SHALL ever be in an "unset" state — Neutral is a valid, intentional classification meaning the activity is neither beneficial nor harmful.
+
+#### Scenario: New activity type defaults to Neutral
+- **WHEN** a user creates a new activity type without explicitly choosing a benefit
+- **THEN** the activity type SHALL be saved with `NetBenefit.Neutral`
+
+#### Scenario: Existing stored value 0 is treated as Neutral
+- **WHEN** an activity type with the previously stored `None` value (`0`) is loaded
+- **THEN** it SHALL be displayed and treated as `Neutral` without any data migration
+
+### Requirement: Three-option net benefit selector on activity type form
+The activity type create/edit form SHALL display three selector buttons: Positive (green), Neutral (grey), and Negative (red). The active value SHALL be visually highlighted. There SHALL be no deselect behavior — clicking any button sets that value.
+
+#### Scenario: All three buttons visible
+- **WHEN** a user opens the activity type create or edit form
+- **THEN** Positive, Neutral, and Negative buttons SHALL all be displayed
+
+#### Scenario: Active button is highlighted
+- **WHEN** a user clicks the Neutral button
+- **THEN** the Neutral button SHALL appear in its filled/active style and Positive/Negative buttons SHALL appear in outline style
+
+#### Scenario: Switching from Positive to Neutral
+- **WHEN** a user with Positive selected clicks Neutral
+- **THEN** Neutral SHALL become active and Positive SHALL become outline
+
+### Requirement: Neutral activity types appear in activity lists
+Neutral activity types SHALL appear in all activity list views: Home recent activities, Activities page list, and Calendar view.
+
+#### Scenario: Neutral activities shown in Home list
+- **WHEN** the Home page loads recent activities
+- **THEN** activities of a neutral type SHALL be included in the list
+
+#### Scenario: Neutral activities shown in Activities page
+- **WHEN** the user views the Activities list page
+- **THEN** activities of a neutral type SHALL appear without suppression
+
+### Requirement: Neutral activity types excluded from Home chart
+The Home page goal/duration chart SHALL exclude activity types with `NetBenefit.Neutral`. Only `Positive` and `Negative` types SHALL be plotted.
+
+#### Scenario: Neutral type not plotted in chart
+- **WHEN** the Home chart is rendered and a neutral activity type has logged data
+- **THEN** that activity type SHALL NOT appear as a bar or data point in the chart
+
+#### Scenario: Positive and Negative still plotted
+- **WHEN** the Home chart is rendered
+- **THEN** activity types with Positive or Negative benefit SHALL appear in the chart as before

--- a/openspec/changes/archive/2026-05-29-add-neutral-benefit/tasks.md
+++ b/openspec/changes/archive/2026-05-29-add-neutral-benefit/tasks.md
@@ -1,0 +1,22 @@
+## 1. Model Update
+
+- [x] 1.1 Rename `None` to `Neutral` in `Trainer/Models/NetBenefit.cs` (keep integer value `0`)
+- [x] 1.2 Find and update all references to `NetBenefit.None` across the codebase (compiler errors will catch any missed ones)
+
+## 2. Activity Type Form (UI Selector)
+
+- [x] 2.1 Update `ActivityTypeEntry.razor` to add a Neutral button between Positive and Negative (Bootstrap `btn-secondary` / `btn-outline-secondary` styling)
+- [x] 2.2 Simplify `ToggleNetBenefit` to a direct assignment — remove the toggle-off-to-None branch since Neutral is always valid
+- [x] 2.3 Verify the three-button layout renders correctly on mobile viewport
+
+## 3. Home Chart
+
+- [x] 3.1 In `Index.razor` `UpdateGoalDurationChart`, update the `.Where` filter from `!= NetBenefit.None` to `!= NetBenefit.Neutral` (rename only — intent unchanged)
+- [x] 3.2 Add a `NetBenefit.Neutral` case to the color switch in `Index.razor` (e.g., `rgba(108, 117, 125, 0.8)`) to prevent a fallthrough
+
+## 4. Verification
+
+- [x] 4.1 Create a Neutral activity type and confirm it appears in the Home recent-activities list and Activities page
+- [x] 4.2 Confirm the Neutral activity type does NOT appear in the Home chart
+- [x] 4.3 Confirm existing Positive and Negative activity types are unaffected
+- [x] 4.4 Confirm a previously-stored `None` (value `0`) activity type loads correctly as Neutral

--- a/openspec/specs/neutral-benefit/spec.md
+++ b/openspec/specs/neutral-benefit/spec.md
@@ -1,0 +1,47 @@
+### Requirement: Neutral is the default net benefit classification
+`NetBenefit.Neutral` (integer value `0`, renamed from `None`) SHALL be the default value for all activity types. No activity type SHALL ever be in an "unset" state — Neutral is a valid, intentional classification meaning the activity is neither beneficial nor harmful.
+
+#### Scenario: New activity type defaults to Neutral
+- **WHEN** a user creates a new activity type without explicitly choosing a benefit
+- **THEN** the activity type SHALL be saved with `NetBenefit.Neutral`
+
+#### Scenario: Existing stored value 0 is treated as Neutral
+- **WHEN** an activity type with the previously stored `None` value (`0`) is loaded
+- **THEN** it SHALL be displayed and treated as `Neutral` without any data migration
+
+### Requirement: Three-option net benefit selector on activity type form
+The activity type create/edit form SHALL display three selector buttons: Positive (green), Neutral (grey), and Negative (red). The active value SHALL be visually highlighted. There SHALL be no deselect behavior — clicking any button sets that value.
+
+#### Scenario: All three buttons visible
+- **WHEN** a user opens the activity type create or edit form
+- **THEN** Positive, Neutral, and Negative buttons SHALL all be displayed
+
+#### Scenario: Active button is highlighted
+- **WHEN** a user clicks the Neutral button
+- **THEN** the Neutral button SHALL appear in its filled/active style and Positive/Negative buttons SHALL appear in outline style
+
+#### Scenario: Switching from Positive to Neutral
+- **WHEN** a user with Positive selected clicks Neutral
+- **THEN** Neutral SHALL become active and Positive SHALL become outline
+
+### Requirement: Neutral activity types appear in activity lists
+Neutral activity types SHALL appear in all activity list views: Home recent activities, Activities page list, and Calendar view.
+
+#### Scenario: Neutral activities shown in Home list
+- **WHEN** the Home page loads recent activities
+- **THEN** activities of a neutral type SHALL be included in the list
+
+#### Scenario: Neutral activities shown in Activities page
+- **WHEN** the user views the Activities list page
+- **THEN** activities of a neutral type SHALL appear without suppression
+
+### Requirement: Neutral activity types excluded from Home chart
+The Home page goal/duration chart SHALL exclude activity types with `NetBenefit.Neutral`. Only `Positive` and `Negative` types SHALL be plotted.
+
+#### Scenario: Neutral type not plotted in chart
+- **WHEN** the Home chart is rendered and a neutral activity type has logged data
+- **THEN** that activity type SHALL NOT appear as a bar or data point in the chart
+
+#### Scenario: Positive and Negative still plotted
+- **WHEN** the Home chart is rendered
+- **THEN** activity types with Positive or Negative benefit SHALL appear in the chart as before


### PR DESCRIPTION
Implements #33  add neutral benefit type by repurposing the existing None (unset) state of NetBenefit.